### PR TITLE
Set up devcontainer config files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
+RUN apt-get update
+
+RUN pip install --upgrade pip
+# Install production dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN python -m pip install -r /tmp/requirements.txt
+RUN rm /tmp/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile",
+		"context": ".."
+    },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "python ./server-python/app.py",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode": {
+            "extensions": ["ms-python.python"]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask-cors
+supabase
+python-dotenv


### PR DESCRIPTION
Should be able to use Docker containers to run the server.

Steps:
1. Install docker desktop
2. Install docker extension on vs code
3. There should be a notif in the bottom right from vsc when opening the folder. Click "open in container" and everything else should be automatic. Else, use ctrl+shift+p to open the command palette and click on Dev Containers: Rebuild and Reopen in Container

The container should automatically download and install python as well as the relevant dependencies (eg flask, dotenv), and run app.py.

For future commits, need to ensure that new packages are included in requirements.txt.

